### PR TITLE
github: Drop Python 3.6, add 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Just to quickly fix this:

![image](https://github.com/ZeniteSolar/CAN_IDS/assets/5920286/00624082-9bc3-424a-b73f-75a2477052e3)
